### PR TITLE
Release message only after it has been sent to all connections.

### DIFF
--- a/src/app/spreed-speakfreely-server/roomworker.go
+++ b/src/app/spreed-speakfreely-server/roomworker.go
@@ -193,8 +193,8 @@ func (r *RoomWorker) broadcastHandler(m *MessageRequest) {
 			}
 			//fmt.Printf("%s\n", m.Message)
 			ec.send(m.Message)
-			m.Message.Decref()
 		}
+		m.Message.Decref()
 	}
 
 	m.Message.Incref()


### PR DESCRIPTION
Fixes issue where "Left" event is sent empty to clients.
