### PR TITLE
Allow Makefile variables CONFIG_FILE and CONFIG_PATH to be set externall...

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,8 @@
 
 PKG := app/spreed-speakfreely-server
 EXENAME := spreed-speakfreely-server
-CONFIG_FILE := spreed-speakfreely-server.conf
-CONFIG_PATH := /etc
+CONFIG_FILE ?= spreed-speakfreely-server.conf
+CONFIG_PATH ?= /etc
 
 VENDOR = "$(CURDIR)/vendor"
 GOPATH = "$(VENDOR):$(CURDIR)"


### PR DESCRIPTION
...y.

This allows packaging scripts to alter the location where the config file is installed.
