### PR TITLE
Display contact name and pic from db

### DIFF
--- a/static/js/services/buddylist.js
+++ b/static/js/services/buddylist.js
@@ -473,7 +473,7 @@ define(['underscore', 'modernizr', 'avltree', 'text!partials/buddy.html', 'text!
 			}
 			// Update display picture.
 			if (contact) {
-				display.buddyPicture = contact.buddyPicture || null;
+				display.buddyPicture = contact.buddyPicture || status.buddyPicture || null;
 				this.updateBuddyPicture(display);
 			} else if (status.buddyPicture) {
 				display.buddyPicture = status.buddyPicture || null;


### PR DESCRIPTION
If a user is a contact, show their display name and pic as saved in the contacts db when the contact was created.
