### PR TITLE
Update toastr.js to 2.0.3.

### DIFF
--- a/src/styles/libs/toastr/toastr.scss
+++ b/src/styles/libs/toastr/toastr.scss
@@ -1,9 +1,9 @@
 /*
  * Toastr
  * Version 2.0.1
- * Copyright 2012 John Papa and Hans Fjällemark.  
- * All Rights Reserved.  
- * Use, reproduction, distribution, and modification of this code is subject to the terms and 
+ * Copyright 2012 John Papa and Hans Fjällemark.
+ * All Rights Reserved.
+ * Use, reproduction, distribution, and modification of this code is subject to the terms and
  * conditions of the MIT license, available at http://www.opensource.org/licenses/mit-license.php
  *
  * Author: John Papa and Hans Fjällemark

--- a/static/js/libs/toastr.js
+++ b/static/js/libs/toastr.js
@@ -1,310 +1,338 @@
 ﻿/*
  * Toastr
- * Version 2.0.1
- * Copyright 2012 John Papa and Hans Fjällemark.  
- * All Rights Reserved.  
- * Use, reproduction, distribution, and modification of this code is subject to the terms and 
+ * Copyright 2012-2014 John Papa and Hans Fjällemark.
+ * All Rights Reserved.
+ * Use, reproduction, distribution, and modification of this code is subject to the terms and
  * conditions of the MIT license, available at http://www.opensource.org/licenses/mit-license.php
  *
  * Author: John Papa and Hans Fjällemark
+ * ARIA Support: Greta Krafsig
  * Project: https://github.com/CodeSeven/toastr
  */
 ; (function (define) {
-	define(['jquery'], function ($) {
-		return (function () {
-			var version = '2.0.1';
-			var $container;
-			var listener;
-			var toastId = 0;
-			var toastType = {
-				error: 'error',
-				info: 'info',
-				success: 'success',
-				warning: 'warning'
-			};
+    define(['jquery'], function ($) {
+        return (function () {
+            var $container;
+            var listener;
+            var toastId = 0;
+            var toastType = {
+                error: 'error',
+                info: 'info',
+                success: 'success',
+                warning: 'warning'
+            };
 
-			var toastr = {
-				clear: clear,
-				error: error,
-				getContainer: getContainer,
-				info: info,
-				options: {},
-				subscribe: subscribe,
-				success: success,
-				version: version,
-				warning: warning
-			};
+            var toastr = {
+                clear: clear,
+                remove: remove,
+                error: error,
+                getContainer: getContainer,
+                info: info,
+                options: {},
+                subscribe: subscribe,
+                success: success,
+                version: '2.0.3',
+                warning: warning
+            };
 
-			return toastr;
+            return toastr;
 
-			//#region Accessible Methods
-			function error(message, title, optionsOverride) {
-				return notify({
-					type: toastType.error,
-					iconClass: getOptions().iconClasses.error,
-					message: message,
-					optionsOverride: optionsOverride,
-					title: title
-				});
-			}
+            //#region Accessible Methods
+            function error(message, title, optionsOverride) {
+                return notify({
+                    type: toastType.error,
+                    iconClass: getOptions().iconClasses.error,
+                    message: message,
+                    optionsOverride: optionsOverride,
+                    title: title
+                });
+            }
 
-			function info(message, title, optionsOverride) {
-				return notify({
-					type: toastType.info,
-					iconClass: getOptions().iconClasses.info,
-					message: message,
-					optionsOverride: optionsOverride,
-					title: title
-				});
-			}
+            function getContainer(options, create) {
+                if (!options) { options = getOptions(); }
+                $container = $('#' + options.containerId);
+                if ($container.length) {
+                    return $container;
+                }
+                if(create) {
+                    $container = createContainer(options);
+                }
+                return $container;
+            }
 
-			function subscribe(callback) {
-				listener = callback;
-			}
+            function info(message, title, optionsOverride) {
+                return notify({
+                    type: toastType.info,
+                    iconClass: getOptions().iconClasses.info,
+                    message: message,
+                    optionsOverride: optionsOverride,
+                    title: title
+                });
+            }
 
-			function success(message, title, optionsOverride) {
-				return notify({
-					type: toastType.success,
-					iconClass: getOptions().iconClasses.success,
-					message: message,
-					optionsOverride: optionsOverride,
-					title: title
-				});
-			}
+            function subscribe(callback) {
+                listener = callback;
+            }
 
-			function warning(message, title, optionsOverride) {
-				return notify({
-					type: toastType.warning,
-					iconClass: getOptions().iconClasses.warning,
-					message: message,
-					optionsOverride: optionsOverride,
-					title: title
-				});
-			}
+            function success(message, title, optionsOverride) {
+                return notify({
+                    type: toastType.success,
+                    iconClass: getOptions().iconClasses.success,
+                    message: message,
+                    optionsOverride: optionsOverride,
+                    title: title
+                });
+            }
 
-			function clear($toastElement) {
-				var options = getOptions();
-				if (!$container) { getContainer(options); }
-				if ($toastElement && $(':focus', $toastElement).length === 0) {
-					$toastElement[options.hideMethod]({
-						duration: options.hideDuration,
-						easing: options.hideEasing,
-						complete: function () { removeToast($toastElement); }
-					});
-					return;
-				}
-				if ($container.children().length) {
-					$container[options.hideMethod]({
-						duration: options.hideDuration,
-						easing: options.hideEasing,
-						complete: function () { $container.remove(); }
-					});
-				}
-			}
-			//#endregion
+            function warning(message, title, optionsOverride) {
+                return notify({
+                    type: toastType.warning,
+                    iconClass: getOptions().iconClasses.warning,
+                    message: message,
+                    optionsOverride: optionsOverride,
+                    title: title
+                });
+            }
 
-			//#region Internal Methods
+            function clear($toastElement) {
+                var options = getOptions();
+                if (!$container) { getContainer(options); }
+                if (!clearToast($toastElement, options)) {
+                    clearContainer(options);
+                }
+            }
 
-			function getDefaults() {
-				return {
-					tapToDismiss: true,
-					toastClass: 'toast',
-					containerId: 'toast-container',
-					debug: false,
+            function remove($toastElement) {
+                var options = getOptions();
+                if (!$container) { getContainer(options); }
+                if ($toastElement && $(':focus', $toastElement).length === 0) {
+                    removeToast($toastElement);
+                    return;
+                }
+                if ($container.children().length) {
+                    $container.remove();
+                }
+            }
+            //#endregion
 
-					showMethod: 'fadeIn', //fadeIn, slideDown, and show are built into jQuery
-					showDuration: 300,
-					showEasing: 'swing', //swing and linear are built into jQuery
-					onShown: undefined,
-					hideMethod: 'fadeOut',
-					hideDuration: 1000,
-					hideEasing: 'swing',
-					onHidden: undefined,
+            //#region Internal Methods
 
-					extendedTimeOut: 1000,
-					iconClasses: {
-						error: 'toast-error',
-						info: 'toast-info',
-						success: 'toast-success',
-						warning: 'toast-warning'
-					},
-					iconClass: 'toast-info',
-					positionClass: 'toast-top-right',
-					timeOut: 5000, // Set timeOut and extendedTimeout to 0 to make it sticky
-					titleClass: 'toast-title',
-					messageClass: 'toast-message',
-					target: 'body',
-					closeHtml: '<button>&times;</button>',
-					newestOnTop: true
-				};
-			}
+            function clearContainer(options){
+                var toastsToClear = $container.children();
+                for (var i = toastsToClear.length - 1; i >= 0; i--) {
+                    clearToast($(toastsToClear[i]), options);
+                };
+            }
 
-			function publish(args) {
-				if (!listener) {
-					return;
-				}
-				listener(args);
-			}
+            function clearToast($toastElement, options){
+                if ($toastElement && $(':focus', $toastElement).length === 0) {
+                    $toastElement[options.hideMethod]({
+                        duration: options.hideDuration,
+                        easing: options.hideEasing,
+                        complete: function () { removeToast($toastElement); }
+                    });
+                    return true;
+                }
+                return false;
+            }
 
-			function notify(map) {
-				var
-					options = getOptions(),
-					iconClass = map.iconClass || options.iconClass;
+            function createContainer(options) {
+                $container = $('<div/>')
+                    .attr('id', options.containerId)
+                    .addClass(options.positionClass)
+                    .attr('aria-live', 'polite')
+                    .attr('role', 'alert');
 
-				if (typeof (map.optionsOverride) !== 'undefined') {
-					options = $.extend(options, map.optionsOverride);
-					iconClass = map.optionsOverride.iconClass || iconClass;
-				}
+                $container.appendTo($(options.target));
+                return $container;
+            }
 
-				toastId++;
+            function getDefaults() {
+                return {
+                    tapToDismiss: true,
+                    toastClass: 'toast',
+                    containerId: 'toast-container',
+                    debug: false,
 
-				$container = getContainer(options);
-				var
-					intervalId = null,
-					$toastElement = $('<div/>'),
-					$titleElement = $('<div/>'),
-					$messageElement = $('<div/>'),
-					$closeElement = $(options.closeHtml),
-					response = {
-						toastId: toastId,
-						state: 'visible',
-						startTime: new Date(),
-						options: options,
-						map: map
-					};
+                    showMethod: 'fadeIn', //fadeIn, slideDown, and show are built into jQuery
+                    showDuration: 300,
+                    showEasing: 'swing', //swing and linear are built into jQuery
+                    onShown: undefined,
+                    hideMethod: 'fadeOut',
+                    hideDuration: 1000,
+                    hideEasing: 'swing',
+                    onHidden: undefined,
 
-				if (map.iconClass) {
-					$toastElement.addClass(options.toastClass).addClass(iconClass);
-				}
+                    extendedTimeOut: 1000,
+                    iconClasses: {
+                        error: 'toast-error',
+                        info: 'toast-info',
+                        success: 'toast-success',
+                        warning: 'toast-warning'
+                    },
+                    iconClass: 'toast-info',
+                    positionClass: 'toast-top-right',
+                    timeOut: 5000, // Set timeOut and extendedTimeout to 0 to make it sticky
+                    titleClass: 'toast-title',
+                    messageClass: 'toast-message',
+                    target: 'body',
+                    closeHtml: '<button>&times;</button>',
+                    newestOnTop: true
+                };
+            }
 
-				if (map.title) {
-					$titleElement.append(map.title).addClass(options.titleClass);
-					$toastElement.append($titleElement);
-				}
+            function publish(args) {
+                if (!listener) { return; }
+                listener(args);
+            }
 
-				if (map.message) {
-					$messageElement.append(map.message).addClass(options.messageClass);
-					$toastElement.append($messageElement);
-				}
+            function notify(map) {
+                var options = getOptions(),
+                    iconClass = map.iconClass || options.iconClass;
 
-				if (options.closeButton) {
-					$closeElement.addClass('toast-close-button');
-					$toastElement.prepend($closeElement);
-				}
+                if (typeof (map.optionsOverride) !== 'undefined') {
+                    options = $.extend(options, map.optionsOverride);
+                    iconClass = map.optionsOverride.iconClass || iconClass;
+                }
 
-				$toastElement.hide();
-				if (options.newestOnTop) {
-					$container.prepend($toastElement);
-				} else {
-					$container.append($toastElement);
-				}
+                toastId++;
+
+                $container = getContainer(options, true);
+                var intervalId = null,
+                    $toastElement = $('<div/>'),
+                    $titleElement = $('<div/>'),
+                    $messageElement = $('<div/>'),
+                    $closeElement = $(options.closeHtml),
+                    response = {
+                        toastId: toastId,
+                        state: 'visible',
+                        startTime: new Date(),
+                        options: options,
+                        map: map
+                    };
+
+                if (map.iconClass) {
+                    $toastElement.addClass(options.toastClass).addClass(iconClass);
+                }
+
+                if (map.title) {
+                    $titleElement.append(map.title).addClass(options.titleClass);
+                    $toastElement.append($titleElement);
+                }
+
+                if (map.message) {
+                    $messageElement.append(map.message).addClass(options.messageClass);
+                    $toastElement.append($messageElement);
+                }
+
+                if (options.closeButton) {
+                    $closeElement.addClass('toast-close-button').attr("role", "button");
+                    $toastElement.prepend($closeElement);
+                }
+
+                $toastElement.hide();
+                if (options.newestOnTop) {
+                    $container.prepend($toastElement);
+                } else {
+                    $container.append($toastElement);
+                }
 
 
-				$toastElement[options.showMethod](
-					{ duration: options.showDuration, easing: options.showEasing, complete: options.onShown }
-				);
-				if (options.timeOut > 0) {
-					intervalId = setTimeout(hideToast, options.timeOut);
-				}
+                $toastElement[options.showMethod](
+                    { duration: options.showDuration, easing: options.showEasing, complete: options.onShown }
+                );
 
-				$toastElement.hover(stickAround, delayedhideToast);
-				if (!options.onclick && options.tapToDismiss) {
-					$toastElement.click(hideToast);
-				}
-				if (options.closeButton && $closeElement) {
-					$closeElement.click(function (event) {
-					   if( event.stopPropagation ) {
-                          event.stopPropagation();
-                       } else if( event.cancelBubble !== undefined && event.cancelBubble !== true ) {
-                          event.cancelBubble = true;
-                       }
-						hideToast(true);
-					});
-				}
+                if (options.timeOut > 0) {
+                    intervalId = setTimeout(hideToast, options.timeOut);
+                }
 
-				if (options.onclick) {
-					$toastElement.click(function () {
-						options.onclick();
-						hideToast();
-					});
-				}
+                $toastElement.hover(stickAround, delayedHideToast);
+                if (!options.onclick && options.tapToDismiss) {
+                    $toastElement.click(hideToast);
+                }
 
-				publish(response);
+                if (options.closeButton && $closeElement) {
+                    $closeElement.click(function (event) {
+                        if( event.stopPropagation ) {
+                            event.stopPropagation();
+                        } else if( event.cancelBubble !== undefined && event.cancelBubble !== true ) {
+                            event.cancelBubble = true;
+                        }
+                        hideToast(true);
+                    });
+                }
 
-				if (options.debug && console) {
-					console.log(response);
-				}
+                if (options.onclick) {
+                    $toastElement.click(function () {
+                        options.onclick();
+                        hideToast();
+                    });
+                }
 
-				return $toastElement;
+                publish(response);
 
-				function hideToast(override) {
-					if ($(':focus', $toastElement).length && !override) {
-						return;
-					}
-					return $toastElement[options.hideMethod]({
-						duration: options.hideDuration,
-						easing: options.hideEasing,
-						complete: function () {
-							removeToast($toastElement);
-							if (options.onHidden) {
-								options.onHidden();
-							}
-							response.state = 'hidden';
-							response.endTime = new Date(),
-							publish(response);
-						}
-					});
-				}
+                if (options.debug && console) {
+                    console.log(response);
+                }
 
-				function delayedhideToast() {
-					if (options.timeOut > 0 || options.extendedTimeOut > 0) {
-						intervalId = setTimeout(hideToast, options.extendedTimeOut);
-					}
-				}
+                return $toastElement;
 
-				function stickAround() {
-					clearTimeout(intervalId);
-					$toastElement.stop(true, true)[options.showMethod](
-						{ duration: options.showDuration, easing: options.showEasing }
-					);
-				}
-			}
-			function getContainer(options) {
-				if (!options) { options = getOptions(); }
-				$container = $('#' + options.containerId);
-				if ($container.length) {
-					return $container;
-				}
-				$container = $('<div/>')
-					.attr('id', options.containerId)
-					.addClass(options.positionClass);
-				$container.appendTo($(options.target));
-				return $container;
-			}
+                function hideToast(override) {
+                    if ($(':focus', $toastElement).length && !override) {
+                        return;
+                    }
+                    return $toastElement[options.hideMethod]({
+                        duration: options.hideDuration,
+                        easing: options.hideEasing,
+                        complete: function () {
+                            removeToast($toastElement);
+                            if (options.onHidden && response.state !== 'hidden') {
+                                options.onHidden();
+                            }
+                            response.state = 'hidden';
+                            response.endTime = new Date();
+                            publish(response);
+                        }
+                    });
+                }
 
-			function getOptions() {
-				return $.extend({}, getDefaults(), toastr.options);
-			}
+                function delayedHideToast() {
+                    if (options.timeOut > 0 || options.extendedTimeOut > 0) {
+                        intervalId = setTimeout(hideToast, options.extendedTimeOut);
+                    }
+                }
 
-			function removeToast($toastElement) {
-				if (!$container) { $container = getContainer(); }
-				if ($toastElement.is(':visible')) {
-					return;
-				}
-				$toastElement.remove();
-				$toastElement = null;
-				if ($container.children().length === 0) {
-					$container.remove();
-				}
-			}
-			//#endregion
+                function stickAround() {
+                    clearTimeout(intervalId);
+                    $toastElement.stop(true, true)[options.showMethod](
+                        { duration: options.showDuration, easing: options.showEasing }
+                    );
+                }
+            }
 
-		})();
-	});
+            function getOptions() {
+                return $.extend({}, getDefaults(), toastr.options);
+            }
+
+            function removeToast($toastElement) {
+                if (!$container) { $container = getContainer(); }
+                if ($toastElement.is(':visible')) {
+                    return;
+                }
+                $toastElement.remove();
+                $toastElement = null;
+                if ($container.children().length === 0) {
+                    $container.remove();
+                }
+            }
+            //#endregion
+
+        })();
+    });
 }(typeof define === 'function' && define.amd ? define : function (deps, factory) {
-	if (typeof module !== 'undefined' && module.exports) { //Node
-		module.exports = factory(require('jquery'));
-	} else {
-		window['toastr'] = factory(window['jQuery']);
-	}
+    if (typeof module !== 'undefined' && module.exports) { //Node
+        module.exports = factory(require('jquery'));
+    } else {
+        window['toastr'] = factory(window['jQuery']);
+    }
 }));


### PR DESCRIPTION
#2.0.3 (2014-05-17)
## Bug Fixes
- positionClass changes were not being honored due to 2.0.2 release changes. Refactored getContainer to only get the container, unless a 2nd boolean parameter is passed in in which case it will also create it if the container did not exist [871c2a6](https://github.com/CodeSeven/toastr/commit/871c2a6e438bb6b996cfb80286720604a4cf00fd)
#2.0.2 (2014-04-29)
## Features
- Added simple ARIA reader support ([45c6362](https://github.com/CodeSeven/toastr/commit/45c63628476f6b085a6579dc681f4fe61ba5820c))
- Added SASS support (direct port of CSS for now) ([b4c8b34](https://github.com/CodeSeven/toastr/commit/b4c8b3460efb8aa51c730dd38c35ef6b025db2cc))
## Bug Fixes
- Added sourcemap for the min file ([1da4bd1](https://github.com/CodeSeven/toastr/commit/1da4bd1dad21bcfc7fcfe73da1abb185cf2c3f9f))
- IE 8 does not support stopPropagation on the event ([6989573](https://github.com/CodeSeven/toastr/commit/698957325a8e7bf63990f71ee409b911d69bc8ec))
- Media query width fixes ([ea2f5db](https://github.com/CodeSeven/toastr/commit/ea2f5db6e5314dcfe48eb34176583849c177c00e))
- Fix of onHidden firing twice when clicking on it then moving mouse out of toast ([ad613b9](https://github.com/CodeSeven/toastr/commit/ad613b9f18feeec630497590b85ca75c52141ea3) , [#105](https://github.com/CodeSeven/toastr/issues/105))
- Clear all toasts followed by a new toast now displays correctly ([3126a53](https://github.com/CodeSeven/toastr/commit/3126a533e0ab12ec3ff374e155a37fd38bd23bb6) , [#149](https://github.com/CodeSeven/toastr/issues/149) , [#118](https://github.com/CodeSeven/toastr/issues/118))
## Breaking Changes
- None
