### PR TITLE
Ignore files in `build/*` for pre-commit jshint

### DIFF
--- a/src/hooks/pre-commit.hook
+++ b/src/hooks/pre-commit.hook
@@ -33,6 +33,9 @@ for file in `git diff-index --cached --name-only HEAD --diff-filter=ACMR| grep "
         */libs/*)
             echo "Not checking library ${file}"
             ;;
+        build/*)
+            echo "Not checking build ${file}"
+            ;;
         *)
             echo "Checking ${file}"
             nf=`git checkout-index --temp ${file} | cut -f 1`


### PR DESCRIPTION
Update pre commit hook to not jshint files in `build/*`
