### PR TITLE
Always show uploaded presentation if no presentation is active yet.

### DIFF
--- a/static/js/directives/presentation.js
+++ b/static/js/directives/presentation.js
@@ -518,8 +518,8 @@ define(['jquery', 'underscore', 'text!partials/presentation.html', 'bigscreen'],
 					});
 				});
 				var presentation = uploadPresentation(file);
-				if ($scope.availablePresentations.length === 1) {
-					// this is the first presentation, show immediately
+				if (!$scope.currentPresentation) {
+					// no presentation active, show immediately
 					$scope.selectPresentation(presentation);
 				}
 			};


### PR DESCRIPTION
This fixes issue where presentation mode with an active presentation is toggled and a new presentation is uploaded.
