### PR TITLE
Hide add contact star if user is not logged in.

### DIFF
--- a/static/partials/buddy.html
+++ b/static/partials/buddy.html
@@ -1,4 +1,4 @@
-<div class="buddy" ng-class="{'contact': contact, 'withSubline': display.subline || session.Userid}">
+<div class="buddy" ng-class="{'contact': contact, 'withSubline': display.subline || (userid && session.Userid)}">
     <div class="buddyPicture"><i class="fa fa-user"/><img ng-show="display.buddyPicture" alt ng-src="{{display.buddyPicture}}"/></div>
     <div class="buddy1">{{session.Id|displayName}}</div>
     <div class="buddy2"><span ng-show="session.Userid"><i class="fa contact" data-action="contact"></i><span ng-show="session.count"> ({{session.count}})</span></span> <span title="{{display.sublineFull}}">{{display.subline}}</span></div>


### PR DESCRIPTION
When the user is not logged, in a star is shown next to logged in buddies. When clicking on the star nothing happens except a debug log for the user to login.  Change the behavior to hide the stars next to logged in buddies till the user is logged in themselves.
