### PR TITLE
Fixed extension timeout triggering unconditionally.

### DIFF
--- a/static/js/services/screensharing.js
+++ b/static/js/services/screensharing.js
@@ -162,10 +162,12 @@ define(['underscore', 'webrtc.adapter'], function(_) {
 								});
 							}
 						}, 100);
-						// Add a timeout of 30 seconds.
+						// The installation has been installed, but initialization might not work
 						$timeout(function() {
-							waiting = false;
-							d.reject("Timeout while waiting for extension getting installed");
+							if (waiting) {
+								waiting = false;
+								d.reject("Timeout while waiting for extension to become available");
+							}
 						}, 30000);
 					}, function(err) {
 						console.log("Auto install of extension failed.", err);


### PR DESCRIPTION
There was an issue with the timeout that waited for the extension to become available on auto-install, which always triggered after 30 seconds (and showed a message), even if the extension already initialized.
