### PR TITLE
Reset for buddyPictureUpload

### DIFF
--- a/static/js/directives/buddypictureupload.js
+++ b/static/js/directives/buddypictureupload.js
@@ -119,7 +119,7 @@ define(['jquery', 'underscore', 'text!partials/buddypictureupload.html', 'bootst
 			};
 
 			var clearPicture = function() {
-				$(".file-input-name").get(0).innerHTML = "";
+				$(".file-input-name").empty();
 				$scope.imgData = null;
 				$scope.prevImage.src = "";
 				$scope.prevImage.style.cssText = null;


### PR DESCRIPTION
Implement a complete reset for buddyPictureUpload on cancel which removes image and image related data from scope. Add reset button when image is loaded that resets preview back to the state when image was first shown.
