### PR TITLE
Dramatically reduce output produced by js minification.

### DIFF
--- a/build/build.js
+++ b/build/build.js
@@ -20,6 +20,7 @@
  */
 /*jshint -W030 */
 ({
+    logLevel: 2,
 	baseUrl: '../static/js',
 	mainConfigFile: '../static/js/main.js',
 	optimize: 'uglify2',
@@ -33,7 +34,7 @@
 				DEBUG: false
 			}
 		},
-		warnings: true,
+		warnings: false,
 		mangle: true
 	},
 	wrap: false,


### PR DESCRIPTION
Means that a single build doesn't blow out your scrollback :+1: 
