### PR TITLE
Don't rely on dpkg-parsechangelog to get version.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -182,7 +182,7 @@ else
 fi
 AC_SUBST(NODEJS_SUPPORT_PO2JSON)
 
-VERSION=`dpkg-parsechangelog | $SED -n 's/^Version: //p'`
+VERSION=`head -n1 $PWD/debian/changelog | $AWK -F'[[()]]' '{print $2}'`
 PACKAGE_VERSION="$VERSION"
 PACKAGE_STRING="$PACKAGE_NAME $PACKAGE_VERSION"
 AC_DEFINE_UNQUOTED(VERSION, ["$VERSION"], [Version number of package])


### PR DESCRIPTION
This utility only exists on Debian based platforms.
