### PR TITLE
Fix detected po2json version when the module is installed globally.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -173,7 +173,7 @@ if test x"${NPM}" != x"" ; then
     else
         AC_MSG_RESULT([ok])
         AC_MSG_CHECKING([for version of po2json])
-        PO2JSON_VERSION=`{ $NPM list --global & $NPM list; } 2>&1 | $GREP po2json | $SED 's/^.*po2json@//'`
+        PO2JSON_VERSION=`{ $NPM list --global & $NPM list; } 2>&1 | $GREP -v 'required' | $GREP po2json@ | $SED 's/^.*po2json@//'`
         AC_MSG_RESULT([$PO2JSON_VERSION])
         NODEJS_SUPPORT_PO2JSON=yes
     fi


### PR DESCRIPTION
Previously this added garbage to the version string, which made configure output confusing in this case.
