### PR TITLE
Keep Firefox window from scrolling right in presentations

### DIFF
--- a/src/styles/components/_presentation.scss
+++ b/src/styles/components/_presentation.scss
@@ -55,8 +55,12 @@
   text-shadow: 1px 1px 1px white;
 }
 
-.mainPresentation #presentation {
-  display: block;
+.mainPresentation {
+  position: fixed;
+  width: 100%;
+  #presentation {
+    display: block;
+  }
 }
 
 .presentationpane {


### PR DESCRIPTION
Fix FS#1934: Presentation mode - right arrow key scrolls window with presentations slides in Firefox on Mac. 
