### PR TITLE
Clear input type file value for uploaded pictures on cancel.

### DIFF
--- a/static/js/directives/buddypictureupload.js
+++ b/static/js/directives/buddypictureupload.js
@@ -124,6 +124,7 @@ define(['jquery', 'underscore', 'text!partials/buddypictureupload.html'], functi
 				$scope.imgData = null;
 				$scope.prevImage.src = "";
 				$scope.prevImage.style.cssText = null;
+				$scope.clearInput();
 			};
 
 			$scope.cancelPictureUpload = function() {
@@ -203,6 +204,9 @@ define(['jquery', 'underscore', 'text!partials/buddypictureupload.html'], functi
 		var link = function($scope, $element) {
 
 			$scope.prevImage = $element.find("img.preview").get(0);
+			$scope.clearInput = function() {
+				$element.find("input[type=file]")[0].value = "";
+			};
 
 			// Bind change event of file upload form.
 			$element.find("input[type=file]").on("change", $scope.handlePictureUpload);


### PR DESCRIPTION
Fix FS#1933: upload buddy picture - can upload same picture only once without reload on chrome.
