### PR TITLE
Keep Firefox from scrolling right when in presentation

### DIFF
--- a/static/js/directives/presentation.js
+++ b/static/js/directives/presentation.js
@@ -743,6 +743,16 @@ define(['jquery', 'underscore', 'text!partials/presentation.html', 'bigscreen'],
 				event.preventDefault();
 			});
 
+			$(document).on("keydown", function(event) {
+				if (!$scope.layout.presentation) {
+					return;
+				}
+				if ($(event.target).is("input,textarea,select")) {
+					return;
+				}
+				event.preventDefault();
+			});
+
 			$scope.$watch("layout.presentation", function(newval, oldval) {
 				if (newval && !oldval) {
 					$scope.showPresentation();


### PR DESCRIPTION
Keep Firefox window from scrolling right when using the right arrow key in presentations.
