### PR TITLE
Update travis npm install.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,7 @@ install:
   - sudo apt-get -y install nodejs rubygems python-babel
   - sudo gem install oj
   - sudo gem install compass
-  - npm install -g po2json
-  - npm install -g autoprefixer
+  - npm install
 
 script:
   - ./autogen.sh


### PR DESCRIPTION
Update travis `install:` to install npm packages locally. 

Fixes requiring of a global package. Travis uses [nvm](https://github.com/creationix/nvm). nvm [corrected](https://github.com/creationix/nvm/issues/586) [NODE_PATH](http://nodejs.org/api/modules.html#modules_loading_from_the_global_folders) environment variable which allowed requiring of global packages.