### PR TITLE
Update make scss-lint

### DIFF
--- a/src/styles/Makefile.am
+++ b/src/styles/Makefile.am
@@ -46,4 +46,6 @@ styleshint:
 
 styleslint:
 	@if [ "$(SCSS_LINT)" = "" ]; then echo "Command 'scss-lint' not found, required when linting styles"; exit 1; fi
-	$(SCSS_LINT) -c scss.yml
+	@echo "Please be patient, this takes a while..."
+	@files=`find . -not -path "*/libs/*" -name "*.scss"|sort -u`; \
+	for f in $$files; do $(SCSS_LINT) -c scss.yml $$f; done

--- a/src/styles/scss.yml
+++ b/src/styles/scss.yml
@@ -1,7 +1,3 @@
-scss_files: "**/*.scss"
-
-exclude: "libs/**"
-
 linters:
   BangFormat:
     enabled: true


### PR DESCRIPTION
Fix scss-lint behavior of not showing all `IdSelector` errors when a global `IdSelector` is set. You can see the behavior well when within `/src/styles/`. Execute `scss-lint -c scss.yml|grep IdSelector` and notice how many errors are shown. Edit `components/_screensharing.scss` and insert `// scss-lint:disable IdSelector` at the top of the file. Execute `scss-lint -c scss.yml|grep IdSelector` and notice how many errors from other files are suppressed.