### PR TITLE
No need for "allow-same-origin" in presentation sandboxes.

### DIFF
--- a/static/js/directives/odfcanvas.js
+++ b/static/js/directives/odfcanvas.js
@@ -231,7 +231,7 @@ define(['require', 'underscore', 'jquery', 'text!partials/odfcanvas_sandbox.html
 		return {
 			restrict: 'E',
 			replace: true,
-			template: '<div class="canvasContainer odfcontainer"><iframe allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true" sandbox="allow-scripts allow-same-origin"></iframe></div>',
+			template: '<div class="canvasContainer odfcontainer"><iframe allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true" sandbox="allow-scripts"></iframe></div>',
 			controller: controller
 		};
 

--- a/static/js/directives/pdfcanvas.js
+++ b/static/js/directives/pdfcanvas.js
@@ -289,7 +289,7 @@ define(['require', 'underscore', 'jquery', 'text!partials/pdfcanvas_sandbox.html
 		return {
 			restrict: 'E',
 			replace: true,
-			template: '<div class="canvasContainer"><iframe allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true" sandbox="allow-scripts allow-same-origin"></iframe></div>',
+			template: '<div class="canvasContainer"><iframe allowfullscreen="true" mozallowfullscreen="true" webkitallowfullscreen="true" sandbox="allow-scripts"></iframe></div>',
 			controller: controller
 		};
 


### PR DESCRIPTION
This further improves security.