### PR TITLE
Add support for inserting a link to the webrtc system test

### DIFF
--- a/static/partials/settings.html
+++ b/static/partials/settings.html
@@ -96,6 +96,7 @@
       </settings-media>
       <settings-settings>
         <legend>{{_('General')}}</legend>
+        <webrtc-system-test></webrtc-system-test>
         <div class="form-group">
           <label class="col-xs-4 control-label">{{_('Language')}}</label>
           <div class="col-xs-8">


### PR DESCRIPTION
Insert a `webrtc-system-test` element which can be used by plugins to link to a webrtc system test.