### PR TITLE
Don't return users twice in "Welcome" from global room.

### DIFF
--- a/src/app/spreed-webrtc-server/roomworker.go
+++ b/src/app/spreed-webrtc-server/roomworker.go
@@ -207,10 +207,12 @@ func (r *roomWorker) GetUsers() []*DataSession {
 			}
 		}
 		r.mutex.RUnlock()
-		// Include connections to global room.
-		for _, ec := range r.manager.GlobalUsers() {
-			if !appender(ec) {
-				break
+		if r.id != r.manager.globalRoomID {
+			// Include connections to global room.
+			for _, ec := range r.manager.GlobalUsers() {
+				if !appender(ec) {
+					break
+				}
 			}
 		}
 


### PR DESCRIPTION
`roomWorker.GetUsers` returns the users in the current and the global room. These got duplicated if the current room was the global room.