### PR TITLE
Improve handling of peercall event remoteStreamAdded

### DIFF
--- a/static/js/directives/screenshare.js
+++ b/static/js/directives/screenshare.js
@@ -95,9 +95,11 @@ define(['jquery', 'underscore', 'text!partials/screenshare.html', 'text!partials
 				mediaStream.webrtc.doSubscribeScreenshare(from, token, {
 					created: function(peerscreenshare) {
 						peerscreenshare.e.on("remoteStreamAdded", function(event, stream) {
-							$scope.$apply(function(scope) {
-								scope.addRemoteStream(stream, peerscreenshare);
-							});
+							if (stream) {
+								$scope.$apply(function(scope) {
+									scope.addRemoteStream(stream, peerscreenshare);
+								});
+							}
 						});
 						peerscreenshare.e.on("remoteStreamRemoved", function(event, stream) {
 							safeApply($scope, function(scope) {

--- a/static/js/services/videowaiter.js
+++ b/static/js/services/videowaiter.js
@@ -36,7 +36,7 @@ define(["underscore"], function(_) {
 				}
 				return;
 			}
-			var videoTracks = stream.getVideoTracks();
+			var videoTracks = stream && stream.getVideoTracks() || [];
 			//console.log("wait for video", videoTracks.length, video.currentTime, video.videoHeight, video);
 			if (videoTracks.length === 0 && this.count >= 10) {
 				cb(false, video, stream);


### PR DESCRIPTION
The `peercall` event `remoteStreamAdded` can be triggered twice and at times without stream information.  Handle cases when the event is triggered with [null](https://github.com/strukturag/spreed-webrtc/commit/a44cedc52d7495573747c4791f34e6655467cd86#diff-22b49df16d07524e035cc6f8b9e39af7R155).

This PR fixes `undefined` errors and multiple screensharing screens being appended for a stream.