### PR TITLE
Ensure ui stays on the left edge when in fullscreen

### DIFF
--- a/src/styles/global/_base.scss
+++ b/src/styles/global/_base.scss
@@ -39,6 +39,7 @@ body {
 
   > .ui {
     height: 100%;
+    left: 0;
     min-width: $buddylist-width;
     position: absolute;
     width: 100%;


### PR DESCRIPTION
Chrome was not handling the position of the page correctly when in full screen. Explicitly set page to left edge of window.