### PR TITLE
Fix autoprefixer

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "dependencies": {
-    "autoprefixer": ">= 3.1.0",
+    "autoprefixer": ">= 3.1.0 <= 5.2.1",
     "po2json": ">= 0.4.1",
     "jshint": ">= 2.5.5"
   }


### PR DESCRIPTION
Autoprefixer has moved to using the [postcss-cli](https://github.com/postcss/postcss). Limit upper version to keep `autoprefixer` binary and move to postcss-cli at a later time.