### PR TITLE
Have hound ignore subfolders of js/static/libs/

### DIFF
--- a/.javascript_ignore
+++ b/.javascript_ignore
@@ -1,1 +1,1 @@
-static/js/libs/**.js
+static/js/libs/


### PR DESCRIPTION
Hound should not run jshint under `js/static/libs/` or its subfolders. See http://jshint.com/docs/cli/ under ignoring files.