### PR TITLE
Fix wrong type for syscall.Setrlimit on FreeBSD (#244)

### DIFF
--- a/src/app/spreed-webrtc-server/main.go
+++ b/src/app/spreed-webrtc-server/main.go
@@ -367,13 +367,13 @@ func runner(runtime phoenix.Runtime) error {
 	// Try to increase number of file open files. This only works as root.
 	maxfd, err := runtime.GetInt("http", "maxfd")
 	if err == nil {
-		rLimit.Max = uint64(maxfd)
-		rLimit.Cur = uint64(maxfd)
+		rLimit.Max = rlim_t(maxfd)
+		rLimit.Cur = rlim_t(maxfd)
 		err = syscall.Setrlimit(syscall.RLIMIT_NOFILE, &rLimit)
 		if err != nil {
 			log.Println("Error setting max open files", err)
 		} else {
-			log.Printf("Set max open files successfully to %d\n", uint64(maxfd))
+			log.Printf("Set max open files successfully to %d\n", rlim_t(maxfd))
 		}
 	}
 

--- a/src/app/spreed-webrtc-server/types_freebsd.go
+++ b/src/app/spreed-webrtc-server/types_freebsd.go
@@ -1,0 +1,24 @@
+// Copyright 2013 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+// rlim_t converts an int to the OS specific type for rlim_t.  UNIX defines
+// this to be uint64:
+//   http://pubs.opengroup.org/onlinepubs/007904975/basedefs/sys/resource.h.html
+// For legacy reasons FreeBSD defines this as int64:
+//   https://github.com/freebsd/freebsd/blob/d1a65cb7ef2fa0cefbf00f16367a7ba99edc0457/sys/sys/_types.h#L55
+func rlim_t(i int) int64 {
+	return int64(i)
+}

--- a/src/app/spreed-webrtc-server/types_unix.go
+++ b/src/app/spreed-webrtc-server/types_unix.go
@@ -1,0 +1,21 @@
+// Copyright 2013 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// +build darwin linux netbsd openbsd
+
+package main
+
+func rlim_t(i int) uint64 {
+	return uint64(i)
+}


### PR DESCRIPTION
Changes originally from https://github.com/bradfitz/runsit/commit/b5768b6a34bf710c6a871b0f4c32d9b59fcb08f6