### PR TITLE
Fix biased random string generator

### DIFF
--- a/src/app/spreed-webrtc-server/random.go
+++ b/src/app/spreed-webrtc-server/random.go
@@ -23,6 +23,7 @@ package main
 
 import (
 	"crypto/rand"
+	"math/big"
 	pseudoRand "math/rand"
 	"time"
 )
@@ -31,19 +32,24 @@ const (
 	dict = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 )
 
+// NewRandomInt returns a random integer in range [0, max[
+// Tries to use crypto/rand and falls back to math/rand
+func NewRandomInt(max int) int {
+
+	rand, err := rand.Int(rand.Reader, big.NewInt(int64(max)))
+	if err != nil {
+		// Fallback to pseudo-random
+		return pseudoRand.Intn(max)
+	}
+	return int(rand.Int64())
+
+}
+
 func NewRandomString(length int) string {
 
 	buf := make([]byte, length)
-	_, err := rand.Read(buf)
-	if err != nil {
-		// fallback to pseudo-random
-		for i := 0; i < length; i++ {
-			buf[i] = dict[pseudoRand.Intn(len(dict))]
-		}
-	} else {
-		for i := 0; i < length; i++ {
-			buf[i] = dict[int(buf[i])%len(dict)]
-		}
+	for i := 0; i < length; i++ {
+		buf[i] = dict[NewRandomInt(len(dict))]
 	}
 	return string(buf)
 

--- a/src/app/spreed-webrtc-server/random.go
+++ b/src/app/spreed-webrtc-server/random.go
@@ -28,7 +28,7 @@ import (
 )
 
 const (
-	dict = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVW0123456789"
+	dict = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
 )
 
 func NewRandomString(length int) string {


### PR DESCRIPTION
The random string generator had two issues:
  1. It was not using the full upper+lowercase alphabet
  2. It was incorrectly using the modulo operator to uniformly select characters from the dictionary

Without fixing issue 2., the function would return one of the first 8 characters more likely than one of the last 54 chars:
One of `abcdefgh` would be picked with a probability of 5/256, one of `ijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789` only with a probability of 4/256