### PR TITLE
Make conferences more consistent

### DIFF
--- a/static/js/directives/audiovideo.js
+++ b/static/js/directives/audiovideo.js
@@ -31,12 +31,6 @@ define(['jquery', 'underscore', 'text!partials/audiovideo.html', 'text!partials/
 			var streams = {};
 			var calls = {};
 
-			var getStreamId = function(stream, currentcall) {
-				var id = currentcall.id + "-" + stream.id;
-				//console.log("Created stream ID", id);
-				return id;
-			};
-
 			$scope.container = $element[0];
 			$scope.layoutparent = $element.parent();
 
@@ -58,7 +52,7 @@ define(['jquery', 'underscore', 'text!partials/audiovideo.html', 'text!partials/
 
 			$scope.addRemoteStream = function(stream, currentcall) {
 
-				var id = getStreamId(stream, currentcall);
+				var id = currentcall.getStreamId(stream);
 				console.log("New stream", id);
 
 				if (streams.hasOwnProperty(id)) {
@@ -76,7 +70,7 @@ define(['jquery', 'underscore', 'text!partials/audiovideo.html', 'text!partials/
 					callscope = calls[currentcall.id];
 					if (callscope.dummy) {
 						// Current call is marked as dummy. Use it directly.
-						var dummyId = getStreamId(callscope.dummy, currentcall);
+						var dummyId = currentcall.getStreamId(callscope.dummy);
 						subscope = streams[dummyId];
 						if (subscope) {
 							subscope.dummy = null;
@@ -198,7 +192,7 @@ define(['jquery', 'underscore', 'text!partials/audiovideo.html', 'text!partials/
 
 			$scope.removeRemoteStream = function(stream, currentcall) {
 
-				var id = getStreamId(stream, currentcall);
+				var id = currentcall.getStreamId(stream);
 				console.log("Stream removed", id);
 
 				var subscope = streams[id];

--- a/static/js/mediastream/peercall.js
+++ b/static/js/mediastream/peercall.js
@@ -52,6 +52,18 @@ define(['jquery', 'underscore', 'mediastream/utils', 'mediastream/peerconnection
 		//console.log("Set initiate", this.initiate, this);
 	};
 
+	PeerCall.prototype.getStreamId = function(stream) {
+		var streamid = stream.id;
+		var id = this.id + "-" + streamid;
+		if (!this.stream.hasOwnProperty(streamid) || this.streams[streamid] === stream) {
+			this.streams[streamid] = stream;
+		} else {
+			console.warn("A different stream is already registered, not replacing", stream, this.streams[stream.id])
+		}
+		//console.log("Created stream ID", id);
+		return id;
+	};
+
 	PeerCall.prototype.createPeerConnection = function(success_cb, error_cb) {
 
 		var peerconnection = this.peerconnection = new PeerConnection(this.webrtc, this);

--- a/static/js/mediastream/webrtc.js
+++ b/static/js/mediastream/webrtc.js
@@ -297,26 +297,21 @@ function($, _, PeerCall, PeerConference, PeerXfer, PeerScreenshare, UserMedia, u
 					return;
 				}
 				console.log("Bye process.");
-				if (targetcall === this.currentcall) {
-					var newcurrentcall;
-					if (this.currentconference) {
-						// Hand over current call to next conference call.
-						newcurrentcall = this.currentconference.handOver();
-					}
-					if (newcurrentcall) {
+				if (this.currentconference) {
+					// Hand over current call to next conference call.
+					var newcurrentcall = this.currentconference.callClosed(targetcall);
+					targetcall.close()
+					if (newcurrentcall && newcurrentcall != this.currentcall) {
 						this.currentcall = newcurrentcall;
-						targetcall.close()
-						//this.api.sendBye(targetcall.id, null);
 						this.e.triggerHandler("peercall", [newcurrentcall]);
+					}
+					if (this.currentconference && !this.currentconference.checkEmpty()) {
 						this.e.triggerHandler("peerconference", [this.currentconference]);
-					} else {
-						this.doHangup("receivedbye", targetcall.id);
-						this.e.triggerHandler("bye", [data.Reason, from, to, to2]);
 					}
 				} else {
 					this.doHangup("receivedbye", targetcall.id);
-					this.e.triggerHandler("bye", [data.Reason, from, to, to2]);
 				}
+				this.e.triggerHandler("bye", [data.Reason, from, to, to2]);
 				break;
 			case "Conference":
 				if (!this.currentcall || data.indexOf(this.currentcall.id) === -1) {


### PR DESCRIPTION
There was a case where a three-party conference got downgraded to a p2p session and then upgraded to a three-party conference again, that the two remaining participants created their own PeerConference object resulting in a "split-brain" conference.

Looks like this also fixes #282.