### PR TITLE
Major refactoring of call / conference handling.

### DIFF
--- a/static/js/controllers/statusmessagecontroller.js
+++ b/static/js/controllers/statusmessagecontroller.js
@@ -25,8 +25,8 @@ define([], function() {
 	// StatusmessageController
 	return ["$scope", "mediaStream", function($scope, mediaStream) {
 
-		$scope.doHangup = function() {
-			mediaStream.webrtc.doHangup();
+		$scope.doHangup = function(reason, id) {
+			mediaStream.webrtc.doHangup(reason, id);
 		}
 		$scope.doAbort = function() {
 			mediaStream.webrtc.doHangup("abort", $scope.dialing);
@@ -35,10 +35,10 @@ define([], function() {
 			mediaStream.connector.reconnect();
 		}
 		$scope.doAccept = function() {
-			mediaStream.webrtc.doAccept();
+			mediaStream.webrtc.doAccept($scope.incoming);
 		}
-		$scope.doReject = function() {
-			mediaStream.webrtc.doHangup('reject');
+		$scope.doReject = function(id) {
+			mediaStream.webrtc.doHangup('reject', id, $scope.incoming);
 		}
 
 	}];

--- a/static/js/directives/buddylist.js
+++ b/static/js/directives/buddylist.js
@@ -56,6 +56,13 @@ define(['underscore', 'text!partials/buddylist.html'], function(_, template) {
 				$scope.$apply(updateBuddyListVisibility);
 			});
 
+			$scope.$watch("peer", function() {
+				if ($scope.peer) {
+					// Also reset the buddylist if the peer is cleared after the "done" event.
+					updateBuddyListVisibility();
+				}
+			});
+
 			$scope.$on("room.joined", function(ev) {
 				inRoom = true;
 				updateBuddyListVisibility();

--- a/static/js/mediastream/peerconnection.js
+++ b/static/js/mediastream/peerconnection.js
@@ -33,11 +33,16 @@ define(['jquery', 'underscore', 'webrtc.adapter'], function($, _) {
 		this.pc = null;
 		this.datachannel = null;
 		this.datachannelReady = false;
+		this.readyForRenegotiation = true;
 
 		if (currentcall) {
 			this.createPeerConnection(currentcall);
 		}
 
+	};
+
+	PeerConnection.prototype.setReadyForRenegotiation = function(ready) {
+		this.readyForRenegotiation = !!ready;
 	};
 
 	PeerConnection.prototype.createPeerConnection = function(currentcall) {
@@ -318,7 +323,6 @@ define(['jquery', 'underscore', 'webrtc.adapter'], function($, _) {
 	};
 
 	PeerConnection.prototype.createAnswer = function() {
-
 		return this.pc.createAnswer.apply(this.pc, arguments);
 
 	};


### PR DESCRIPTION
Removed difference between single peer-to-peer calls and conferences
with multiple peers. There is only a single code path now that creates
calls and stores them in a conference (which holds all active calls).
With this also fixed some timing issues that could cause conference
peers to not send or receive media streams.

Should help with some of the issues reported in #276.