### PR TITLE
Various fixes to conference error handling

### DIFF
--- a/static/js/controllers/uicontroller.js
+++ b/static/js/controllers/uicontroller.js
@@ -638,8 +638,11 @@ define(['jquery', 'underscore', 'bigscreen', 'moment', 'sjcl', 'modernizr', 'web
 					$scope.setConnectedStatus();
 					break;
 				case "failed":
+					var wasConnected = !currentcall.closed;
 					mediaStream.webrtc.doHangup("failed", currentcall.id);
-					alertify.dialog.alert(translation._("Peer connection failed. Check your settings."));
+					if (!wasConnected) {
+						alertify.dialog.alert(translation._("Peer connection failed. Check your settings."));
+					}
 					break;
 			}
 		});

--- a/static/js/directives/audiovideo.js
+++ b/static/js/directives/audiovideo.js
@@ -354,7 +354,7 @@ define(['jquery', 'underscore', 'text!partials/audiovideo.html', 'text!partials/
 
 			mediaStream.webrtc.e.on("statechange", function(event, iceConnectionState, currentcall) {
 
-				if (!$scope.haveStreams) {
+				if (!$scope.haveStreams || currentcall.closed) {
 					return;
 				}
 


### PR DESCRIPTION
- Don't show "Failed to establish" message if connection was already established before.
- Don't add empty video component if call was already closed.
- Try to recover from (some) lost p2p connection state (see https://github.com/strukturag/spreed-webrtc/commit/c8763deb58d75ad537fd94771185cb370e9c1833 for details).
- Fix moving between conference rooms (was not working, reported in #276)