### PR TITLE
Include user status in "Joined" event.

### DIFF
--- a/go/channelling/session.go
+++ b/go/channelling/session.go
@@ -154,6 +154,7 @@ func (s *Session) JoinRoom(roomName, roomType string, credentials *DataRoomCrede
 				Userid: s.userid,
 				Ua:     s.Ua,
 				Prio:   s.Prio,
+				Status: s.Status,
 			},
 		})
 	} else {

--- a/static/js/controllers/uicontroller.js
+++ b/static/js/controllers/uicontroller.js
@@ -588,10 +588,6 @@ define(['jquery', 'underscore', 'bigscreen', 'moment', 'sjcl', 'modernizr', 'web
 			}
 		};
 
-		$scope.$on("room.joined", function(ev) {
-			$scope.updateStatus(true);
-		});
-
 		mediaStream.connector.e.on("open error close", function(event) {
 			$timeout.cancel(ttlTimeout);
 			$scope.userid = $scope.suserid = null;


### PR DESCRIPTION
Previously, each user broadcasted the status after a "Room" event was
received. This caused a short time for all other participants where
the buddy list showed "Participant X" instead of the real user name.