### PR TITLE
Only install git hook if cloned from git.

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -1,9 +1,11 @@
 #!/bin/sh
 
-# the pre-commit hook performs various formatting checks
-if test ! \( -x .git/hooks/pre-commit -a -L .git/hooks/pre-commit \); then \
-    rm -f .git/hooks/pre-commit; \
-    ln -s ../../src/hooks/pre-commit.hook .git/hooks/pre-commit; \
+if [ -d ".git/hooks" ]; then
+    # the pre-commit hook performs various formatting checks
+    if test ! \( -x .git/hooks/pre-commit -a -L .git/hooks/pre-commit \); then \
+        rm -f .git/hooks/pre-commit; \
+        ln -s ../../src/hooks/pre-commit.hook .git/hooks/pre-commit; \
+    fi
 fi
 
 if [ -x "`which autoreconf 2>/dev/null`" ] ; then


### PR DESCRIPTION
For source tarballs, the `.git/hooks` folder does not exist, so an error
is shown when running `autogen.sh`. With this change, the hook is not
installed in such cases.

Saw this in #300 (but is not causing the problem reported there).