### PR TITLE
Add support for extra.d directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ vendor/*
 /build/out/
 /.sass-cache
 /extra
+/extra.d
 /src/i18n/*.mo
 server.key
 server.csr

--- a/go/channelling/context.go
+++ b/go/channelling/context.go
@@ -21,14 +21,21 @@
 
 package channelling
 
+import (
+	"html/template"
+)
+
 type Context struct {
-	App       string // Main client script
-	Cfg       *Config
-	Host      string
-	Ssl       bool
-	Csp       bool
-	Languages []string
-	Room      string `json:"-"`
-	Scheme    string `json:"-"`
-	Origin    string `json:",omitempty"`
+	App        string // Main client script
+	Cfg        *Config
+	Host       string
+	Ssl        bool
+	Csp        bool
+	Languages  []string
+	Room       string        `json:"-"`
+	Scheme     string        `json:"-"`
+	Origin     string        `json:",omitempty"`
+	S          string        `json:",omitempty"`
+	ExtraDHead template.HTML `json:"-"`
+	ExtraDBody template.HTML `json:"-"`
 }

--- a/html/head.html
+++ b/html/head.html
@@ -11,4 +11,5 @@
 <link rel="stylesheet" type="text/css" href="<%.Cfg.S%>/css/font-awesome.min.css">
 <link rel="stylesheet" type="text/css" href="<%.Cfg.S%>/css/main.min.css">
 <%template "extra-head" .%>
+<%.ExtraDHead%>
 <script id="globalcontext" type="application/json"><%$%></script><%end%>

--- a/html/main.html
+++ b/html/main.html
@@ -9,5 +9,6 @@
 <ui></ui>
 <script data-main="<%.Cfg.S%>/js/<%.App%>" data-plugin="<%.Cfg.Plugin%>" src="<%.Cfg.S%>/js/libs/require/require.js"></script>
 <%template "extra-body" .%>
+<%.ExtraDBody%>
 </body>
 </html><%end%>

--- a/server.conf.in
+++ b/server.conf.in
@@ -101,14 +101,20 @@ serverRealm = local
 ; Full path to an extra templates directory. Templates in this directory ending
 ; with .html will be parsed on startup and can be used to fill the supported
 ; extra-* template slots. If the extra folder has a sub folder "static", the
-; resources in this static folder will be available as /extra/static/filename
+; resources in this static folder will be available as /extra/static/...
 ; relative to your servers base URL.
 ;extra = /usr/share/spreed-webrtc-server/extra
+; Full path to an extra.d directory. Subfolders in this directory will be
+; searched for head.html and body.html on startup. If found, those templates
+; will be automatically included for the web client. In addition,
+; sub-folder/static will be made available by URL at /extra.d/static/<n>/...
+; relative to your servers base URL.
 ; URL relative to the servers base path for a plugin javascript file which is
 ; automatically loaded on web client start for all users. You can put your
 ; plugin in the extra/static folder (see above) or provide another folder using
 ; a front end webserver. Check the doc folder for more info about plugins and
 ; examples.
+;extra.d = /usr/share/spreed-webrtc-server/extra.d
 ;plugin = extra/static/myplugin.js
 ; Content-Security-Policy HTTP response header value.
 ; Spreed WebRTC requires inline styles, WebSocket connection to itself and

--- a/src/app/spreed-webrtc-server/handler_room.go
+++ b/src/app/spreed-webrtc-server/handler_room.go
@@ -70,7 +70,19 @@ func handleRoomView(room string, w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Prepare context to deliver to HTML..
-	context := &channelling.Context{Cfg: config, App: "main", Host: r.Host, Scheme: scheme, Ssl: ssl, Csp: csp, Languages: langs, Room: room}
+	context := &channelling.Context{
+		Cfg:        config,
+		App:        "main",
+		Host:       r.Host,
+		Scheme:     scheme,
+		Ssl:        ssl,
+		Csp:        csp,
+		Languages:  langs,
+		Room:       room,
+		S:          config.S,
+		ExtraDHead: templatesExtraDHead,
+		ExtraDBody: templatesExtraDBody,
+	}
 
 	// Get URL parameters.
 	r.ParseForm()
@@ -79,10 +91,10 @@ func handleRoomView(room string, w http.ResponseWriter, r *http.Request) {
 	// See https://developers.google.com/webmasters/ajax-crawling/docs/getting-started for details.
 	if _, ok := r.Form["_escaped_fragment_"]; ok {
 		// Render crawlerPage template..
-		err = templates.ExecuteTemplate(w, "crawlerPage", &context)
+		err = templates.ExecuteTemplate(w, "crawlerPage", context)
 	} else {
 		// Render mainPage template.
-		err = templates.ExecuteTemplate(w, "mainPage", &context)
+		err = templates.ExecuteTemplate(w, "mainPage", context)
 	}
 
 	if err != nil {

--- a/src/app/spreed-webrtc-server/utils.go
+++ b/src/app/spreed-webrtc-server/utils.go
@@ -1,7 +1,10 @@
 package main
 
 import (
+	"fmt"
 	"net/http"
+
+	"github.com/gorilla/mux"
 
 	"github.com/strukturag/goacceptlanguageparser"
 )
@@ -14,4 +17,24 @@ func getRequestLanguages(r *http.Request, supportedLanguages []string) []string 
 		langs = goacceptlanguageparser.ParseAcceptLanguage(acceptLanguageHeader[0], supportedLanguages)
 	}
 	return langs
+}
+
+func rewriteExtraDUrl(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+
+		extra, ok := vars["extra"]
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+		path, ok := vars["path"]
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+
+		r.URL.Path = fmt.Sprintf("%s/static/%s", extra, path)
+		h.ServeHTTP(w, r)
+	})
 }


### PR DESCRIPTION
To allow muliple plugins, sorted plugin load and general extensibility
of the web client, the server now supports to load an extra.d folder on
startup.

Sub folders inside extra.d, are loaded in alphabetic order and searched
for head.html and body.html, making it possible to append additional
html code into the <head> and <body> elements for the web client.

Example:
```
	extra.d/
	└── my-plugin
	    ├── body.html
	    ├── head.html
	    └── static
	        ├── css
	        │   └── my-plugin.css
	        └── js
	            └── my-plugin.js
```

Example head.html:
```
	<link rel="stylesheet" href="<%.S%>/css/my-plugin.css">
```

Example body.html:
```
	<script data-plugin="<%.S%>/js/my-plugin.js"></script>
```

This makes it possible to extend the web client with additional
components and/or overwrite existing.