### PR TITLE
Compare HMACs in constant time to mitigate timing attack

### DIFF
--- a/go/channelling/server/users.go
+++ b/go/channelling/server/users.go
@@ -26,6 +26,7 @@ import (
 	"crypto/hmac"
 	"crypto/rand"
 	"crypto/sha256"
+	"crypto/subtle"
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
@@ -95,7 +96,7 @@ func (uh *UsersSharedsecretHandler) Validate(snr *SessionNonceRequest, request *
 	}
 
 	secret := uh.createHMAC(snr.UseridCombo)
-	if snr.Secret != secret {
+	if subtle.ConstantTimeCompare([]byte(snr.Secret), []byte(secret)) != 1 {
 		return "", errors.New("invalid secret")
 	}
 


### PR DESCRIPTION
Issue was introduced in https://github.com/strukturag/spreed-webrtc/commit/a46f36fd486cfef51b3ed53fa2faefdb01ace81f