### PR TITLE
Add Dockerfiles to build minimal Docker

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,0 +1,56 @@
+# Spreed WebRTC server Docker builder
+#
+# This Dockerfile creates a container which builds Spreed WebRTC as found in the
+# current folder, and creates a tarball which can be piped into another Docker
+# container for creating minimal sized Docker containers.
+#
+# First create the builder image:
+#
+#   ```
+#   docker build -t spreed-webrtc-builder -f Dockerfile.build .
+#   ```
+# Next run the builder container, piping its output into the creation of the
+# runner container. This creates a minimal size Docker image which can be used
+# to run Spreed WebRTC in production.
+#
+#   ```
+#   docker run --rm spreed-webrtc-builder | docker build -t spreed-webrtc -f Dockerfile.run -
+#   ```
+
+FROM ubuntu:xenial
+MAINTAINER Simon Eisenmann <simon@struktur.de>
+
+# Set locale.
+RUN locale-gen --no-purge en_US.UTF-8
+ENV LC_ALL en_US.UTF-8
+
+ENV DEBIAN_FRONTEND noninteractive
+
+# Base build dependencies.
+RUN apt-get update && apt-get install -qy \
+	golang \
+	nodejs \
+	build-essential \
+	git \
+	automake \
+	autoconf
+
+# Add and build Spreed WebRTC server.
+ADD . /srv/spreed-webrtc
+WORKDIR /srv/spreed-webrtc
+RUN mkdir -p /usr/share/gocode/src
+RUN ./autogen.sh && \
+	./configure && \
+	make pristine && \
+	make get && \
+	make tarball
+RUN rm /srv/spreed-webrtc/dist_*/*.tar.gz
+RUN mv /srv/spreed-webrtc/dist_*/spreed-webrtc-* /srv/spreed-webrtc/dist
+
+# Add gear required by Dockerfile.run.
+COPY Dockerfile.run /
+COPY scripts/docker_entrypoint.sh /
+
+# Running this image produces a tarball suitable to be piped into another
+# Docker build command.
+CMD tar -cf - -C / Dockerfile.run docker_entrypoint.sh /srv/spreed-webrtc/dist

--- a/Dockerfile.run
+++ b/Dockerfile.run
@@ -1,9 +1,21 @@
-# Spreed WebRTC server in Docker (for development)
+# Spreed WebRTC server in minimal Docker (for production)
 #
-# This Dockerfile creates a container which runs Spreed WebRTC as found in the
-# current folder. It is intended for development.
+# This Dockerfile creates a container which builds Spreed WebRTC as piped in
+# on stdin using another Docker container defined in `Dockerfile.build`.
 #
-# Install docker and then run `docker build -t spreed-webrtc .` to build the
+# First create the builder image:
+#
+#   ```
+#   docker build -t spreed-webrtc-builder -f Dockerfile.build .
+#   ```
+#
+# Next run the builder container, piping its output into the creation of the
+# runner container:
+#
+#   ```
+#   docker run --rm spreed-webrtc-builder | docker build -t spreed-webrtc -f Dockerfile.run -
+#   ```
+#
 # image. Afterwards run the container like this:
 #
 #   ```
@@ -34,49 +46,37 @@
 # `--rm` parameter in the example from above in that case.
 #
 
-FROM ubuntu:xenial
+FROM frolvlad/alpine-glibc:alpine-3.3_glibc-2.23
 MAINTAINER Simon Eisenmann <simon@struktur.de>
 
-# Set locale.
-RUN locale-gen --no-purge en_US.UTF-8
-ENV LC_ALL en_US.UTF-8
+ENV LANG=C.UTF-8
 
-ENV DEBIAN_FRONTEND noninteractive
-
-# Base build dependencies.
-RUN apt-get update && apt-get install -qy \
-	golang \
-	nodejs \
-	build-essential \
-	git \
-	automake \
-	autoconf
-
-# Add and build Spreed WebRTC server.
-ADD . /srv/spreed-webrtc
-WORKDIR /srv/spreed-webrtc
-RUN ./autogen.sh && \
-	./configure && \
-	make pristine && \
-	make get && \
-	make
-
-# Add runtime dependencies.
-RUN apt-get update && apt-get install -qy \
-	bsdmainutils \
+# Add dependencies.
+RUN apk add --no-cache \
 	openssl
 
-# Add entrypoint.
-COPY scripts/docker_entrypoint.sh /srv/entrypoint.sh
+# Add Spreed WebRTC as provided by Dockerfile.run.
+COPY srv/ /srv
 
-# Create default config file.
+# Move around stuff from tarball to their expected locations.
+RUN mv /srv/spreed-webrtc/dist/loader/* /srv/spreed-webrtc && \
+	mv /srv/spreed-webrtc/dist/www/html /srv/spreed-webrtc && \
+	mv /srv/spreed-webrtc/dist/www/static /srv/spreed-webrtc
+
+# Add entrypoint.
+COPY docker_entrypoint.sh /srv/entrypoint.sh
+
+# Create default config.
 RUN cp -v /srv/spreed-webrtc/server.conf.in /srv/spreed-webrtc/default.conf && \
 	sed -i 's|listen = 127.0.0.1:8080|listen = 0.0.0.0:8080|' /srv/spreed-webrtc/default.conf && \
 	sed -i 's|;root = .*|root = /srv/spreed-webrtc|' /srv/spreed-webrtc/default.conf && \
 	sed -i 's|;listen = 127.0.0.1:8443|listen = 0.0.0.0:8443|' /srv/spreed-webrtc/default.conf && \
 	sed -i 's|;certificate = .*|certificate = /srv/cert.pem|' /srv/spreed-webrtc/default.conf && \
-	sed -i 's|;key = .*|key = /srv/privkey.pem|' /srv/spreed-webrtc/default.conf
-RUN touch /srv/spreed-webrtc/server.conf
+	sed -i 's|;key = .*|key = /srv/privkey.pem|' /srv/spreed-webrtc/default.conf && \
+	touch /etc/spreed-webrtc-server.conf
+
+# Cleanup.
+RUN rm -rf /tmp/* /var/cache/apk/*
 
 # Add mount point for extra things.
 RUN mkdir /srv/extra
@@ -88,4 +88,4 @@ EXPOSE 8443
 
 # Define entry point with default command.
 ENTRYPOINT ["/bin/sh", "/srv/entrypoint.sh", "-dc", "/srv/spreed-webrtc/default.conf"]
-CMD ["-c", "/srv/spreed-webrtc/server.conf"]
+CMD ["-c", "/etc/spreed-webrtc-server.conf"]

--- a/README.md
+++ b/README.md
@@ -138,6 +138,20 @@ https://github.com/coturn/coturn/wiki/turnserver#webrtc-usage
 for more information.
 
 
+## Running with Docker
+
+We provide official Docker images at https://hub.docker.com/r/spreed/webrtc/. Of
+course you can build the Docker image yourself as well. Check the Dockerfiles in
+this repository for details and instructions.
+
+Use the following command to run a Spreed WebRTC Docker container with the
+default settings from our official Spreed WebRTC Docker image.
+
+```
+docker run --rm --name my-spreed-webrtc -p 8080:8080 -p 8443:8443 \
+    -v `pwd`:/srv/extra -i -t spreed/webrtc
+```
+
 ## Setup Screensharing
 
 ### Chrome

--- a/scripts/docker_entrypoint.sh
+++ b/scripts/docker_entrypoint.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+set -e
+
+randomhex() {
+	local size="$1"
+	if [ -z "${size}" ]; then
+		size=32
+	fi
+	local val=$(hexdump -e '4/4 "%08x"' -n${size} /dev/random)
+	echo ${val}
+}
+
+if [ "$NEWCERT" = "1" -o ! -s /srv/cert.pem ]; then
+	echo "Creating new self signed TLS certificate ..."
+	rm -f /srv/privkey.pem
+	rm -f /srv/cert.pem
+	openssl ecparam -genkey -name secp384r1 -out /srv/privkey.pem
+	openssl req -new -x509 -key /srv/privkey.pem \
+				-out /srv/cert.pem -days 3650 \
+				-subj /CN=spreed-webrtc \
+				-config /etc/ssl/openssl.cnf \
+				-sha256 -extensions v3_req
+
+fi
+echo "TLS certificate:"
+openssl x509 -in /srv/cert.pem -text
+
+if [ "$NEWSECRETS" = "1" -o ! -s /srv/secrets.conf ]; then
+	echo "Creating new server secrets ..."
+	rm -f /srv/secrets.conf.tmp
+	echo "SESSION_SECRET=$(randomhex 32)" >>/srv/secrets.conf.tmp
+	echo "ENCRYPTION_SECRET=$(randomhex 32)" >>/srv/secrets.conf.tmp
+	echo "SERVER_TOKEN=$(randomhex 32)" >>/srv/secrets.conf.tmp
+	echo "SHARED_SECRET=$(randomhex 32)" >>/srv/secrets.conf.tmp
+	. /srv/secrets.conf.tmp
+	sed -i -e "s/sessionSecret =.*/sessionSecret = $SESSION_SECRET/" /srv/spreed-webrtc/default.conf
+	sed -i -e "s/encryptionSecret =.*/encryptionSecret = $ENCRYPTION_SECRET/" /srv/spreed-webrtc/default.conf
+	sed -i -e "s/serverToken =.*/serverToken = $SERVER_TOKEN/" /srv/spreed-webrtc/default.conf
+	sed -i -e "s/;sharedsecret_secret =.*/sharedsecret_secret = $SHARED_SECRET/" /srv/spreed-webrtc/default.conf
+	mv /srv/secrets.conf.tmp /srv/secrets.conf
+fi
+echo "Server secrets:"
+cat /srv/secrets.conf
+
+echo "Staring Spreed WebRTC server ..."
+exec /srv/spreed-webrtc/spreed-webrtc-server "$@"


### PR DESCRIPTION
To reduce the Docker image size a seperate build Dockerfile is
introduced. This Docker image produces a tarball of the released and
compiled software which can when be piped into the Dockerfile.run build
process. The result is a minimal image only containing Spreed WebRTC and
the gear to run OpenSSL.

First create the builder image:

```
docker build -t spreed-webrtc-builder -f Dockerfile.build .
```

Next run the builder container, piping its output into the creation of
the runner container:

```
docker run --rm spreed-webrtc-builder | docker build -t spreed-webrtc -f
Dockerfile.run -
```

Afterwards run the container like this:

```
docker run --rm --name my-spreed-webrtc -p 8080:8080 -p 8443:8443 \
	-v `pwd`:/srv/extra -i -t spreed-webrtc
```