### PR TITLE
Docker: Use /dev/urandom instead of /dev/random

### DIFF
--- a/scripts/docker_entrypoint.sh
+++ b/scripts/docker_entrypoint.sh
@@ -6,7 +6,7 @@ randomhex() {
 	if [ -z "${size}" ]; then
 		size=32
 	fi
-	local val=$(hexdump -e '4/4 "%08x"' -n${size} /dev/random)
+	local val=$(hexdump -e '4/4 "%08x"' -n${size} /dev/urandom)
 	echo ${val}
 }
 


### PR DESCRIPTION
#359 