### PR TITLE
Implement config loading via NATS

### DIFF
--- a/dependencies.tsv
+++ b/dependencies.tsv
@@ -8,6 +8,6 @@ github.com/nats-io/nats	git	355b5b97e0842dc94f1106729aa88e33e06317ca	2015-12-09T
 github.com/satori/go.uuid	git	879c5887cd475cd7864858769793b2ceb0d44feb	2016-06-07T14:43:47Z
 github.com/strukturag/goacceptlanguageparser	git	68066e68c2940059aadc6e19661610cf428b6647	2014-02-13T13:31:23Z
 github.com/strukturag/httputils	git	afbf05c71ac03ee7989c96d033a9571ba4ded468	2014-07-02T01:35:33Z
-github.com/strukturag/phoenix	git	31b7f25f4815e6e0b8e7c4010f6e9a71c4165b19	2016-06-01T11:34:58Z
+github.com/strukturag/phoenix	git	8c65e1692d19e1ea84c79d8346bee5747c8ef69c	2016-10-05T15:12:02Z
 github.com/strukturag/sloth	git	74a8bcf67368de59baafe5d3e17aee9875564cfc	2015-04-22T08:59:42Z
 github.com/strukturag/spreed-turnservicecli	git	dcbf3f8eab1c36d4d0e4c6f9b6dce4f060543224	2016-08-29T09:55:47Z

--- a/server.conf.in
+++ b/server.conf.in
@@ -203,16 +203,29 @@ enabled = false
 ;allowRegistration = false
 
 [nats]
+; Set to true, to connect to NATS on startup. If false, all other settins in the
+; [nats] section are ignored. Defaults to false.
+;useNATS = false
 ; Set to true, to enable triggering channelling events via NATS
 ;channelling_trigger = false
+; NATS channel trigger subject. Defaults to 'channelling.trigger'.
 ;channelling_trigger_subject = channelling.trigger
-; NATS server URL
+; NATS server URL.
 ;url = nats://127.0.0.1:4222
-; NATS connect establish timeout in seconds
+; NATS connect establish timeout in seconds.
 ;establishTimeout = 60
 ; Use client_id to distinguish between multipe servers. The value is sent
 ; together with every NATS request. Defaults to empty.
 ;client_id =
+; Set to true, to load additional configuration settings via NATS. The config
+; loaded is applied after loading the [nats] section and all entries extend the
+; configuration files with overwrite. Only takes effect when a NATS server URL
+; is configured. Defaults to false.
+;configFromNATS = false
+;configFromNATSSubject = spreed-webrtc.config.get
+; NATS config load timeout. If 0, then it waits forever, blocking the startup
+; until the configuration was loaded from NATS. Defaults to 0.
+;configFromNATSTimeout = 0
 
 [roomtypes]
 ; You can define room types that should be used for given room names instead of


### PR DESCRIPTION
On server startup the configuration files are loaded as normal. NATS is connected first and if enabled, additional configuration is loaded with a NATS request. This makes it possible to provide additional configuration from other services. NATS configuration is only loaded on startup. So whenever the NATS configuration provider changes the webrtc configuration, it has to trigger a restart of Spreed WebRTC externally.