### PR TITLE
Remove non functional Google+ social share

### DIFF
--- a/static/js/directives/socialshare.js
+++ b/static/js/directives/socialshare.js
@@ -26,7 +26,6 @@ define(['text!partials/socialshare.html'], function(template) {
 		email: "mailto:?subject=_TEXT_%20_URL_",
 		facebook: "https://www.facebook.com/sharer.php?u=_URL_&t=_TEXT_",
 		twitter: "https://twitter.com/share?url=_URL_&text=_TEXT_&via=_SITE_",
-		google: "https://plus.google.com/share?url=_URL_",
 		xing: "https://www.xing.com/app/user?op=share;url=_URL_"
 	};
 

--- a/static/partials/socialshare.html
+++ b/static/partials/socialshare.html
@@ -4,6 +4,5 @@
 	<a title="{{_('Invite by Email')}}" class="btn btn-link btn-sm" data-nw="email"><i class="fa fa-envelope fa-lg email"></i></a>
 	<a title="{{_('Invite with Facebook')}}" class="btn btn-link btn-sm" data-nw="facebook"><i class="fa fa-facebook fa-lg facebook"></i></a>
 	<a title="{{_('Invite with Twitter')}}" class="btn btn-link btn-sm" data-nw="twitter"><i class="fa fa-twitter fa-lg twitter"></i></a>
-	<a title="{{_('Invite with Google Plus')}}" class="btn btn-link btn-sm" data-nw="google"><i class="fa fa-google-plus fa-lg google"></i></a>
 	<a title="{{_('Invite with XING')}}" class="btn btn-link btn-sm" data-nw="xing"><i class="fa fa-xing fa-lg xing"></i></a>
 </div>


### PR DESCRIPTION
Google+ seems to have removed the https://plus.google.com/share endpoint. This change removes the G+ logo and URL.