### PR TITLE
Explicitly pass "outgoing" flag when creating PeerCall object.

### DIFF
--- a/static/js/mediastream/peercall.js
+++ b/static/js/mediastream/peercall.js
@@ -22,12 +22,13 @@
 "use strict";
 define(['jquery', 'underscore', 'mediastream/utils', 'mediastream/peerconnection'], function($, _, utils, PeerConnection) {
 
-	var PeerCall = function(webrtc, id, from, to) {
+	var PeerCall = function(webrtc, id, from, to, outgoing) {
 
 		this.webrtc = webrtc;
 		this.id = id;
 		this.from = from;
 		this.to = to;
+		this.outgoing = !!outgoing;
 
 		this.e = $({}) // events
 
@@ -49,7 +50,7 @@ define(['jquery', 'underscore', 'mediastream/utils', 'mediastream/peerconnection
 	};
 
 	PeerCall.prototype.isOutgoing = function() {
-		return !!this.from;
+		return this.outgoing;
 	};
 
 	PeerCall.prototype.setInitiate = function(initiate) {

--- a/static/js/mediastream/webrtc.js
+++ b/static/js/mediastream/webrtc.js
@@ -461,8 +461,8 @@ function($, _, PeerCall, PeerConference, PeerXfer, PeerScreenshare, UserMedia, u
 
 	};
 
-	WebRTC.prototype.createCall = function(id, from, to) {
-		var call = new PeerCall(this, id, from, to);
+	WebRTC.prototype.createCall = function(id, from, to, outgoing) {
+		var call = new PeerCall(this, id, from, to, outgoing);
 		call.e.on("connectionStateChange", _.bind(function(event, iceConnectionState, currentcall) {
 			this.onConnectionStateChange(iceConnectionState, currentcall);
 		}, this));
@@ -577,7 +577,7 @@ function($, _, PeerCall, PeerConference, PeerXfer, PeerScreenshare, UserMedia, u
 	};
 
 	WebRTC.prototype.doCall = function(id, autocall) {
-		var call = this.createCall(id, null, id);
+		var call = this.createCall(id, null, id, true);
 		call.setInitiate(true);
 		var count = this.conference.getCallsCount();
 		if (!this.conference.addOutgoing(id, call)) {


### PR DESCRIPTION
This fixes #377 where no ringing sound was played back because the call
was not seen as "outgoing" (and also fixes the missing timeout if the
called peer does not pick up).