### PR TITLE
Support fixed username/password TURN credentials.

### DIFF
--- a/go/channelling/config.go
+++ b/go/channelling/config.go
@@ -14,6 +14,8 @@ type Config struct {
 	Renegotiation                   bool                      // Renegotiation flag
 	StunURIs                        []string                  // STUN server URIs
 	TurnURIs                        []string                  // TURN server URIs
+	TurnUsername                    string                    // Username for TURN server
+	TurnPassword                    string                    // Password for TURN server
 	Tokens                          bool                      // True when we got a tokens file
 	Version                         string                    // Server version number
 	UsersEnabled                    bool                      // Flag if users are enabled

--- a/go/channelling/hub.go
+++ b/go/channelling/hub.go
@@ -92,29 +92,38 @@ func (h *hub) ClientInfo(details bool) (clientCount int, sessions map[string]*Da
 }
 
 func (h *hub) CreateTurnData(sender Sender, session *Session) *DataTurn {
-	// Create turn data credentials for shared secret auth with TURN
-	// server. See http://tools.ietf.org/html/draft-uberti-behave-turn-rest-00
-	// and https://code.google.com/p/rfc5766-turn-server/ REST API auth
-	// and set shared secret in TURN server with static-auth-secret.
-	if len(h.turnSecret) == 0 {
-		return &DataTurn{}
-	}
-	id := session.Id
-	bar := sha256.New()
-	bar.Write([]byte(id))
-	id = base64.StdEncoding.EncodeToString(bar.Sum(nil))
-	foo := hmac.New(sha1.New, h.turnSecret)
-	expiration := int32(time.Now().Unix()) + turnTTL
-	user := fmt.Sprintf("%d:%s", expiration, id)
-	foo.Write([]byte(user))
-	password := base64.StdEncoding.EncodeToString(foo.Sum(nil))
+	if len(h.turnSecret) > 0 {
+		// Create turn data credentials for shared secret auth with TURN
+		// server. See http://tools.ietf.org/html/draft-uberti-behave-turn-rest-00
+		// and https://code.google.com/p/rfc5766-turn-server/ REST API auth
+		// and set shared secret in TURN server with static-auth-secret.
+		id := session.Id
+		bar := sha256.New()
+		bar.Write([]byte(id))
+		id = base64.StdEncoding.EncodeToString(bar.Sum(nil))
+		foo := hmac.New(sha1.New, h.turnSecret)
+		expiration := int32(time.Now().Unix()) + turnTTL
+		user := fmt.Sprintf("%d:%s", expiration, id)
+		foo.Write([]byte(user))
+		password := base64.StdEncoding.EncodeToString(foo.Sum(nil))
 
-	return &DataTurn{
-		Username: user,
-		Password: password,
-		Ttl:      turnTTL,
-		Urls:     h.config.TurnURIs,
+		return &DataTurn{
+			Username: user,
+			Password: password,
+			Ttl:      turnTTL,
+			Urls:     h.config.TurnURIs,
+		}
 	}
+
+	if h.config.TurnUsername != "" && h.config.TurnPassword != "" {
+		return &DataTurn{
+			Username: h.config.TurnUsername,
+			Password: h.config.TurnPassword,
+			Urls:     h.config.TurnURIs,
+		}
+	}
+
+	return &DataTurn{}
 }
 
 func (h *hub) GetSession(id string) (session *Session, ok bool) {

--- a/go/channelling/server/config.go
+++ b/go/channelling/server/config.go
@@ -128,6 +128,8 @@ func NewConfig(container phoenix.Container, tokens bool) (*channelling.Config, e
 		Renegotiation:                   container.GetBoolDefault("app", "renegotiation", false),
 		StunURIs:                        stunURIs,
 		TurnURIs:                        turnURIs,
+		TurnUsername:                    container.GetStringDefault("app", "turnUsername", ""),
+		TurnPassword:                    container.GetStringDefault("app", "turnPassword", ""),
 		Tokens:                          tokens,
 		Version:                         version,
 		UsersEnabled:                    container.GetBoolDefault("users", "enabled", false),

--- a/server.conf.in
+++ b/server.conf.in
@@ -57,6 +57,12 @@ listen = 127.0.0.1:8080
 ; See http://tools.ietf.org/html/draft-uberti-behave-turn-rest-00 for details.
 ; A supported TURN server is https://code.google.com/p/rfc5766-turn-server/.
 ;turnSecret = the-default-turn-shared-secret-do-not-keep
+; Fixed username/password credentials to be used for the TURN server.
+; IMPORTANT: This will give all users connected to the spreed-webrtc service
+; access to the credentials, so in almost all cases the shared secret mode
+; should be used instead!!
+;turnUsername = the-turn-username
+;turnPassword = the-turn-secret
 ; Enable renegotiation support. Set to true to tell clients that they can
 ; renegotiate peer connections when required. Firefox support is not complete,
 ; so do not enable if you want compatibility with Firefox clients.


### PR DESCRIPTION
This is required for cases where an external TURN service should be used that only supports authentication with username/password (but not with a shared secret).