### PR TITLE
Fix Go 1.8 compatibility

### DIFF
--- a/html/head.html
+++ b/html/head.html
@@ -12,4 +12,4 @@
 <link rel="stylesheet" type="text/css" href="<%.Cfg.S%>/css/main.min.css">
 <%template "extra-head" .%>
 <%.ExtraDHead%>
-<script id="globalcontext" type="application/json"><%$%></script><%end%>
+<script id="globalcontext" type="application/json"><%json .%></script><%end%>

--- a/src/app/spreed-webrtc-server/main.go
+++ b/src/app/spreed-webrtc-server/main.go
@@ -25,6 +25,7 @@ import (
 	"bytes"
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"flag"
 	"fmt"
 	"html/template"
@@ -208,8 +209,17 @@ func runner(runtime phoenix.Runtime) error {
 	}
 
 	// Load templates.
+	templateFuncMap := template.FuncMap{
+		"json": func(obj interface{}) (template.HTML, error) {
+			data, err := json.Marshal(obj)
+			if err != nil {
+				return "", err
+			}
+			return template.HTML(data), nil
+		},
+	}
 	templates = template.New("")
-	templates.Delims("<%", "%>")
+	templates.Delims("<%", "%>").Funcs(templateFuncMap)
 
 	// Load html templates folder
 	err = filepath.Walk(path.Join(rootFolder, "html"), func(path string, info os.FileInfo, err error) error {


### PR DESCRIPTION
Using the latest Go 1.8 beta (0b2daa56), this is what's output in the `script#globalcontext`:
`{main 0xc420083080 spreed-webrtc-test:7443 true false [de-de de en-us en zh-cn zh]  https  static/ver=1480602944  }`
Go has apparently modified their template system: Objects in templates are no longer JSON-encoded by default. Using this fix, Spreed WebRTC even works when compiled with Go 1.8 :)