### PR TITLE
Initially mute camera/microphone when joining conference rooms.

### DIFF
--- a/static/js/controllers/uicontroller.js
+++ b/static/js/controllers/uicontroller.js
@@ -119,6 +119,8 @@ define(['jquery', 'underscore', 'bigscreen', 'moment', 'sjcl', 'modernizr', 'tex
 
 		var displayName = safeDisplayName;
 
+		var roomTypeConference = "Conference";
+
 		// Init STUN from server config.
 		(function() {
 			var stun = mediaStream.config.StunURIs || [];
@@ -667,7 +669,23 @@ define(['jquery', 'underscore', 'bigscreen', 'moment', 'sjcl', 'modernizr', 'tex
 		});
 
 		$scope.$on("room.updated", function(event, room) {
+			var oldType = $scope.roomType;
 			$scope.roomType = room ? room.Type : null;
+			if (oldType !== roomTypeConference && $scope.roomType == roomTypeConference) {
+				// Switched to conference more, start calls muted by default.
+				$scope.resetAutoMuteState = {
+					"cameraMute": $scope.cameraMute,
+					"microphoneMute": $scope.microphoneMute
+				};
+				$scope.cameraMute = true;
+				$scope.microphoneMute = true;
+			} else if (oldType === roomTypeConference && $scope.roomType !== roomTypeConference) {
+				// No longer in conference room, reset mute state to previous settings.
+				_.each($scope.resetAutoMuteState, function(v, k) {
+					$scope[k] = v;
+				});
+				$scope.resetAutoMuteState = {};
+			}
 		});
 
 		// Apply all layout stuff as classes to our element.

--- a/static/js/controllers/uicontroller.js
+++ b/static/js/controllers/uicontroller.js
@@ -319,8 +319,8 @@ define(['jquery', 'underscore', 'bigscreen', 'moment', 'sjcl', 'modernizr', 'tex
 			mediaStream.webrtc.setVideoMute(cameraMute);
 		});
 
-		$scope.$watch("microphoneMute", function(cameraMute) {
-			mediaStream.webrtc.setAudioMute(cameraMute);
+		$scope.$watch("microphoneMute", function(microphoneMute) {
+			mediaStream.webrtc.setAudioMute(microphoneMute);
 		});
 
 		$scope.$watch("peer", function(c, o) {


### PR DESCRIPTION
Most users have enabled automatic access to devices, so when joining a conference room, they immediately are visible to the other participants.

This might cause privacy issues, so we mute the devices by default and the participant must activate them manually.