### PR TITLE
fix broken docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,8 @@ FROM ubuntu:xenial
 MAINTAINER Simon Eisenmann <simon@struktur.de>
 
 # Set locale.
+RUN apt-get clean && apt-get update
+RUN apt-get install locales
 RUN locale-gen --no-purge en_US.UTF-8
 ENV LC_ALL en_US.UTF-8
 


### PR DESCRIPTION
Current docker build output: /bin/sh: 1: locale-gen: not found
Locale-gen is not provided anymore by ubuntu base image, so it must be installed beforehand.