### PR TITLE
Add option to specify a regular expression for public rooms.

### DIFF
--- a/go/channelling/config.go
+++ b/go/channelling/config.go
@@ -34,6 +34,7 @@ type Config struct {
 	RoomTypes                       map[*regexp.Regexp]string `json:"-"` // Map of regular expression -> room type
 	RoomNameCaseSensitive           bool                      // Whether the room names are case sensitive.
 	LockedRoomJoinableWithPIN       bool                      // Whether locked rooms should be joinable by providing the PIN the room was locked with
+	PublicRoomNames                 *regexp.Regexp            `json:"-"` // Regular expression that specifies room paths that may be created/joined without a user account.
 }
 
 func (config *Config) WithModule(m string) bool {

--- a/go/channelling/server/config.go
+++ b/go/channelling/server/config.go
@@ -119,6 +119,16 @@ func NewConfig(container phoenix.Container, tokens bool) (*channelling.Config, e
 		}
 	}
 
+	publicRoomNamesString := container.GetStringDefault("app", "publicRooms", "")
+	var publicRoomNames *regexp.Regexp
+	if publicRoomNamesString != "" {
+		var err error
+		if publicRoomNames, err = regexp.Compile(publicRoomNamesString); err != nil {
+			return nil, fmt.Errorf("Invalid regular expression '%s': %s", publicRoomNamesString, err)
+		}
+		log.Printf("Allowed public rooms: %s\n", publicRoomNamesString)
+	}
+
 	return &channelling.Config{
 		Title:                           container.GetStringDefault("app", "title", "Spreed WebRTC"),
 		Ver:                             ver,
@@ -148,6 +158,7 @@ func NewConfig(container phoenix.Container, tokens bool) (*channelling.Config, e
 		RoomTypes:                       roomTypes,
 		RoomNameCaseSensitive:           container.GetBoolDefault("app", "caseSensitiveRooms", false),
 		LockedRoomJoinableWithPIN:       container.GetBoolDefault("app", "lockedRoomJoinableWithPIN", true),
+		PublicRoomNames:                 publicRoomNames,
 	}, nil
 }
 

--- a/server.conf.in
+++ b/server.conf.in
@@ -100,6 +100,10 @@ encryptionSecret = tne-default-encryption-block-key
 ; Whether locked rooms should be joinable by providing the PIN the room was
 ; locked with. Optional, defaults to true.
 ;lockedRoomJoinableWithPIN = true
+; Regular expression specifying room names that can be created / joined without
+; a valid user account (even if "authorizeRoomJoin" or "authorizeRoomCreation"
+; is enabled).
+;publicRooms =
 ; Whether the pipelines API should be enabled. Optional, defaults to false.
 ;pipelinesEnabled = false
 ; Server token is a public random string which is used to enhance security of


### PR DESCRIPTION
Public rooms can be created / joined even if "authorizeRoomCreation" or
"authorizeRoomJoin" are set.