### PR TITLE
Removed handling of ice disconnect state to allow automatic reconnect…

### DIFF
--- a/static/js/mediastream/webrtc.js
+++ b/static/js/mediastream/webrtc.js
@@ -484,7 +484,6 @@ function($, _, PeerCall, PeerConference, PeerXfer, PeerScreenshare, UserMedia, u
 		}, this));
 		call.e.on("connectionStateChange", _.bind(function(event, state, currentcall) {
 			switch (state) {
-			case "disconnected":
 			case "failed":
 				this.conference.markDisconnected(currentcall.id);
 				break;


### PR DESCRIPTION
We have been having some issues when making calls the web browser, if the network connection is poor then the call can drop out and fail to re-establish the connection.  The responsible code is:

"disconnected" state is able to recover and reconnect but in spreed-webrtc it is treated the same as "failed":

                                call.e.on("connectionStateChange", _.bind(function(event, state, currentcall) {
                                                switch (state) {
                                                case "disconnected":
                                                case "failed":
                                                                this.conference.markDisconnected(currentcall.id);
                                                                break;
                                                }
                                }, this));

In webrtc.js at line 485 (static\js\mediastream\webrtc.js), the "disconnected" state can occur more often on a poor connection:

From https://lists.w3.org/Archives/Public/public-webrtc/2012Sep/att-0097/WebRTCstatesandcallbacks.pdf 
"Liveness checks have failed for one or more components. This is more aggressive than "failed", and may trigger intermittently (and resolve itself without action) on a flaky network."

The change we have made here is to remove the case "disconnected": and just handle the failed case.  During our testing here we were able to call from a phone to the web brower and disconnect the mobile data on the phone for up to 30 seconds then reconnect mobile data and the call would recover and continue streaming video and audio.  Without this change then upon mobile data disconnection the call would end and no recovery was possible.  